### PR TITLE
Fixed Bug Recreating Session Ids

### DIFF
--- a/src/message/utils.py
+++ b/src/message/utils.py
@@ -49,7 +49,7 @@ class AssistantAPI:
         res = self.request(
             "POST",
             f"/sessions/{self.session_id}/message",
-            json={"input": {"text": text}},
+            json={"input": {"text": text, "options": { "return_context": True }}},
         )
         if res.status_code == 404:
             self.session_id = self.create_session()

--- a/src/message/utils/AssistantAPI.py
+++ b/src/message/utils/AssistantAPI.py
@@ -10,10 +10,12 @@ actionRequirements = {
 }
 
 class AssistantAPI:
-    def __init__(self, session_id=None):
-        self.session_id = (
-            session_id if session_id is not None else self.create_session()
-        )
+    def __init__(self, profile):
+        self.profile = profile
+
+        if not self.profile.assistant_session:
+            self.profile.assistant_session = self.create_session()
+            self.profile.save()
 
     # static methods below
 
@@ -71,11 +73,12 @@ class AssistantAPI:
     def message(self, text):
         res = self.request(
             "POST",
-            f"/sessions/{self.session_id}/message",
+            f"/sessions/{self.profile.assistant_session}/message",
             json={"input": {"text": text, "options": { "return_context": True }}},
         )
         if res.status_code == 404:
-            self.session_id = self.create_session()
+            self.profile.assistant_session = self.create_session()
+            self.profile.save()
             return self.message(text)
 
         try:

--- a/src/message/utils/AssistantAPI.py
+++ b/src/message/utils/AssistantAPI.py
@@ -1,13 +1,21 @@
 import requests
 from requests import HTTPError
 from message.constants import WATSON_ASSISTANT_BASE_URL, WATSON_ASSISTANT_API_KEY
+from message.utils.enums import ActionNames, WatsonEntities
 
+actionRequirements = {
+    ActionNames.AddFilter: [WatsonEntities.FilterField, WatsonEntities.FilterComparison, WatsonEntities.Number],
+    ActionNames.LoadDataset: [WatsonEntities.DatasetName],
+    ActionNames.Clear: []
+}
 
 class AssistantAPI:
     def __init__(self, session_id=None):
         self.session_id = (
             session_id if session_id is not None else self.create_session()
         )
+
+    # static methods below
 
     @classmethod
     def request(cls, method, url, **kwargs):
@@ -37,6 +45,21 @@ class AssistantAPI:
         except HTTPError as e:
             cls.process_error(e)
         return res.json()["session_id"]
+
+    # private methods below
+
+    # check the response by comparing the intent to the actions it can take
+    # then, check and see if any of the actions have all required parameters in the context (by using actionRequirements)
+    # returns T/F
+    def is_complete(self, assistantContext):
+        pass
+
+    # Formats the response to the client. Includes any parameters and respective actions if this is a complete
+    # response.
+    def format_response(self, assistantContext):
+        pass
+
+    # public methods below
 
     def delete_session(self):
         res = self.request("DELETE", f"/sessions/{self.session_id}")

--- a/src/message/utils/enums.py
+++ b/src/message/utils/enums.py
@@ -1,0 +1,13 @@
+from enum import Enum
+
+# these are all the actions that the client knows how to take
+class ActionNames(Enum):
+    AddFilter = "AddFilter"
+    LoadDataset = "LoadDataset"
+    Clear = "Clear"
+
+class WatsonEntities(Enum):
+    Number = "sys-number"
+    DatasetName = "dataset_name"
+    FilterComparison = "filter_comparison"
+    FilterField = "filter_field"

--- a/src/message/views.py
+++ b/src/message/views.py
@@ -3,11 +3,10 @@ from django.shortcuts import render
 from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework import status
-from message.utils import AssistantAPI
+from message.utils.AssistantAPI import AssistantAPI
 from users.models import Profile
 from users.serializers import ProfileSerializer
 
-# Create your views here.
 class MessageView(APIView):
     def post(self, request):
         message_text = request.data.get("inputText")

--- a/src/message/views.py
+++ b/src/message/views.py
@@ -15,13 +15,7 @@ class MessageView(APIView):
         except Profile.DoesNotExist:
             profile = ProfileSerializer(data={"user": request.user}).save()
 
-        if profile.assistant_session:
-            assistant_session = profile.assistant_session
-        else:
-            assistant_session = AssistantAPI.create_session()
-            profile.assistant_session = assistant_session
-            profile.save()
-        assistant_api = AssistantAPI(assistant_session)
+        assistant_api = AssistantAPI(profile)
 
         data = assistant_api.message(message_text)
         return Response(json.dumps(data), status=status.HTTP_200_OK)


### PR DESCRIPTION
Previously, we were creating a new session id for each call (once the originally create one expired). This was because we were updating the session in the assistant API, and not saving that to the database. 

Now, the assistant API will take in the entire profile, and if it needs to update the session id, it will save it on that profile as appropriate.

This means that now, conversations work appropriately with the assistant through our website (context is maintained).

This PR also contains some small refactoring and architecting, which was work intended to get ready to dispatch actions to the client when they are ready to be complete. I decided to send this bugfix PR before I finished all those changes, to prevent this from becoming a very large PR. 