### PR TITLE
Don't prompt if only one dataset loaded.

### DIFF
--- a/src/message/views.py
+++ b/src/message/views.py
@@ -22,12 +22,13 @@ class MessageView(APIView):
         """
         message = request.data.get("input", request.data.get("inputText"))
         config = request.data.get("config", {})
+        datasets = request.data.get("datasets", [])
         try:
             profile = request.user.profile
         except Profile.DoesNotExist:
             profile = ProfileSerializer(data={"user": request.user}).save()
 
-        assistant_api = AssistantAPI(profile)
+        assistant_api = AssistantAPI(profile, datasets)
 
         if config.get("inputFormat") == "speech":
             mime_type = config.get("mimeType")


### PR DESCRIPTION
This is the API side PR for https://github.com/speaq-ai/react-ui/pull/48

In this PR, if only one dataset is loaded, we then send that as the dataset back to the client. We also then send a message to watson, satisfying watson's request for a dataset, so that Watson's conversation tree is then ready for the next user message. 